### PR TITLE
Register with Sass if compass isn't found.

### DIFF
--- a/lib/true.rb
+++ b/lib/true.rb
@@ -1,7 +1,12 @@
+true_stylesheets_path = File.expand_path(File.join(File.dirname(__FILE__), '..', 'sass'))
 begin
   require 'compass'
-  Compass::Frameworks.register('true',
-    :stylesheets_directory => File.expand_path(File.join(File.dirname(__FILE__), '..', 'sass')))
+  Compass::Frameworks.register('true', :stylesheets_directory => true_stylesheets_path)
 rescue LoadError
-  # compass not found, don't register with it.
+  # compass not found, register on the Sass path via the environment.
+  if ENV.has_key?("SASSPATH")
+    ENV["SASSPATH"] = ENV["SASSPATH"] + File::PATH_SEPARATOR + true_stylesheets_path
+  else
+    ENV["SASSPATH"] = true_stylesheets_path
+  end
 end


### PR DESCRIPTION
Register with the Sass CLI if the compass CLI isn't found by injecting true into the `SASSPATH`. This makes true work with `sass -r true ...`
