### PR TITLE
Support for nested blocks

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -52,6 +52,20 @@ var parse = module.exports.parse = function (css) {
   var modules = [];
   var ast = parseCss(css);
 
+  var getModule = function (path, ctx) {
+    ctx = ctx || {modules: modules};
+    if (path.length === 0) {
+      return ctx;
+    } else {
+      var curModule = _.findWhere(ctx.modules, {module: path[0]});
+      if (!curModule) {
+        curModule = {module: path[0], tests: [], modules: []};
+        ctx.modules.push(curModule);
+      }
+      return getModule(path.slice(1), curModule);
+    }
+  };
+
   _.each(_.where(ast.stylesheet.rules, {type: 'rule'}), function (rule) {
     var decls = _.where(rule.declarations, {type: 'declaration'});
     var declPairs = _.zip(
@@ -65,11 +79,7 @@ var parse = module.exports.parse = function (css) {
       if (!selInfo) {
         throw new Error("Can't understand selector: " + sel);
       }
-      var curModule = _.findWhere(modules, {module: selInfo.module});
-      if (!curModule) {
-        curModule = {module: selInfo.module, tests: []};
-        modules.push(curModule);
-      }
+      var curModule = getModule(selInfo.modules);
       var curTest = _.findWhere(curModule.tests, {test: selInfo.test});
       if (!curTest) {
         curTest = {test: selInfo.test, assertions: []};
@@ -121,7 +131,10 @@ var parse = module.exports.parse = function (css) {
 
 var parseSelector = module.exports.parseSelector = function (sel) {
   var rule = selectorParser.parse(sel).rule;
-  var ret = {output: false};
+  var ret = {
+    output: false,
+    modules: [],
+  };
   var x = _parseSelector(rule, ret);
   return x;
 };
@@ -129,7 +142,7 @@ var parseSelector = module.exports.parseSelector = function (sel) {
 
 var _parseSelector = function (rule, ret) {
   if (attrName(rule, 'data-module')) {
-    ret.module = rule.attrs[0].value;
+    ret.modules.push(rule.attrs[0].value);
     return _parseSelector(rule.rule, ret);
   } else if (attrName(rule, 'data-test')) {
     ret.test = rule.attrs[0].value;

--- a/lib/main.js
+++ b/lib/main.js
@@ -10,7 +10,6 @@ var selectorParser = new CssSelectorParser();
 
 
 module.exports.runSass = function (options, describe, it) {
-  var assert = require('assert');
   var sassPath = path.join(__dirname, '..', 'sass');
   if (options.includePaths) {
     options.includePaths.push(sassPath);
@@ -21,26 +20,34 @@ module.exports.runSass = function (options, describe, it) {
   var modules = parse(css);
 
   _.each(modules, function (module) {
-    describe(module.module, function () {
-      _.each(module.tests, function (test) {
-        it(test.test, function () {
-          _.each(test.assertions, function (assertion) {
-            if (!assertion.passed) {
-              var msg = (
-                assertion.description + ' ("' +
-                  assertion.returned + '" ' +
-                  assertion.assert + ' "' +
-                  assertion.expected +
-                  '")'
-              );
-              assert.fail(
-                assertion.returned,
-                assertion.expected,
-                msg,
-                assertion.assert
-              );
-            }
-          });
+    describeModule(module, describe, it);
+  });
+};
+
+var describeModule = function (module, describe, it) {
+  var assert = require('assert');
+  describe(module.module, function () {
+    _.each(module.modules, function (submodule) {
+      describeModule(submodule, describe, it);
+    });
+    _.each(module.tests, function (test) {
+      it(test.test, function () {
+        _.each(test.assertions, function (assertion) {
+          if (!assertion.passed) {
+            var msg = (
+              assertion.description + ' ("' +
+                assertion.returned + '" ' +
+                assertion.assert + ' "' +
+                assertion.expected +
+                '")'
+            );
+            assert.fail(
+              assertion.returned,
+              assertion.expected,
+              msg,
+              assertion.assert
+            );
+          }
         });
       });
     });

--- a/lib/main.js
+++ b/lib/main.js
@@ -122,33 +122,44 @@ var parse = module.exports.parse = function (css) {
 var parseSelector = module.exports.parseSelector = function (sel) {
   var rule = selectorParser.parse(sel).rule;
   var ret = {output: false};
-  var attrName = function (rule, name) {
-    return (rule &&
-            rule.attrs &&
-            rule.attrs.length == 1 &&
-            rule.attrs[0].name === name
-           );
-  };
+  var x = _parseSelector(rule, ret);
+  return x;
+};
+
+
+var _parseSelector = function (rule, ret) {
   if (attrName(rule, 'data-module')) {
     ret.module = rule.attrs[0].value;
-    rule = rule.rule;
-    if (attrName(rule, 'data-test')) {
-      ret.test = rule.attrs[0].value;
-      rule = rule.rule;
-      if (attrName(rule, 'data-assert')) {
-        ret.output = true;
-        ret.assert = rule.attrs[0].value;
-        rule = rule.rule;
-        if (rule.classNames.length === 1 &&
-            _.contains(['input', 'expect'], rule.classNames[0])) {
-          ret.type = rule.classNames[0];
-          return ret;
-        }
-      } else if (rule.classNames.length === 1 &&
-                 rule.classNames[0].slice(0, 7) === 'assert-') {
-        ret.assert = rule.classNames[0].slice(7);
-        return ret;
-      }
-    }
+    return _parseSelector(rule.rule, ret);
+  } else if (attrName(rule, 'data-test')) {
+    ret.test = rule.attrs[0].value;
+    return _parseSelector(rule.rule, ret);
+  } else if (attrName(rule, 'data-assert')) {
+    ret.output = true;
+    ret.assert = rule.attrs[0].value;
+    return _parseSelector(rule.rule, ret);
+  } else if (hasClassName(rule) &&
+             _.contains(['input', 'expect'], rule.classNames[0])) {
+    ret.type = rule.classNames[0];
+    return ret;
+  } else if (hasClassName(rule) &&
+             rule.classNames[0].slice(0, 7) === 'assert-') {
+    ret.assert = rule.classNames[0].slice(7);
+    return ret;
   }
+};
+
+var attrName = function (rule, name) {
+  return (rule &&
+          rule.attrs &&
+          rule.attrs.length == 1 &&
+          rule.attrs[0].name === name
+         );
+};
+
+var hasClassName = function (rule) {
+  return (rule &&
+          rule.classNames &&
+          rule.classNames.length == 1
+         );
 };

--- a/sass/true/_assert.scss
+++ b/sass/true/_assert.scss
@@ -182,7 +182,7 @@
 @mixin _true-assert-stop(
   $result
 ) {
-  @include _true-update(test, $result);
+  @include _true-update($result);
   @include _true-context(assert, null);
 }
 

--- a/sass/true/_assert.scss
+++ b/sass/true/_assert.scss
@@ -183,7 +183,7 @@
   $result
 ) {
   @include _true-update($result);
-  @include _true-context(assert, null);
+  @include _true-context-pop();
 }
 
 

--- a/sass/true/_messages.scss
+++ b/sass/true/_messages.scss
@@ -19,9 +19,14 @@ $-tnl: '\a ';
 ) {
   $selector: null;
 
-  @each $layer in $scope {
-    $this: '[data-#{$layer}="#{_true-context($layer)}"]';
-    $selector: if($selector, '#{$selector} #{$this}', $this);
+  @each $entry in $_true-context {
+    $layer: nth($entry, 1);
+    $name: nth($entry, 2);
+
+    @if ($layer in $scope) {
+      $this: '[data-#{$layer}="#{$name}"]';
+      $selector: if($selector, '#{$selector} #{$this}', $this);
+    }
   }
 
   @return unquote($selector);

--- a/sass/true/_modules.scss
+++ b/sass/true/_modules.scss
@@ -24,13 +24,11 @@
 /// @access private
 /// @group x_private
 /// @param {String} $name - Module name
-/// @require {mixin} _true-reset
 /// @require {mixin} _true-context
 /// @require {mixin} _true-message
 @mixin _true-module-start(
   $name
 ) {
-  @include _true-reset(module);
   @include _true-context(module, $name);
   @include _true-message('# #{$name} ----------', comments);
 }
@@ -42,11 +40,8 @@
 /// Module stop helper
 /// @access private
 /// @group x_private
-/// @require {mixin} _true-reset
 /// @require {mixin} _true-context
 /// @require {mixin} _true-message
 @mixin _true-module-stop {
-  @include _true-update(global, null);
-  @include _true-reset(module);
   @include _true-context(module, null);
 }

--- a/sass/true/_modules.scss
+++ b/sass/true/_modules.scss
@@ -43,5 +43,5 @@
 /// @require {mixin} _true-context
 /// @require {mixin} _true-message
 @mixin _true-module-stop {
-  @include _true-context(module, null);
+  @include _true-context-pop();
 }

--- a/sass/true/_results.scss
+++ b/sass/true/_results.scss
@@ -1,104 +1,16 @@
 // Results
 // =======
 
-/// Initialized results map
+/// Results map
 /// @access private
 /// @group x_private
 /// @type Map
-$_true-results-reset: (
+$_true-results: (
   run: 0,
   pass: 0,
   fail: 0,
   output-to-css: 0,
 );
-
-/// Results map
-/// @access private
-/// @group x_private
-/// @type Map
-/// @require $_true-results-reset
-/// @prop {Map} global [$_true-results-reset] - Global results
-/// @prop {Map} module [$_true-results-reset] - Results for current module
-/// @prop {Map} test [$_true-results-reset] - Results for current test
-$_true-results: (
-  global: $_true-results-reset,
-  module: $_true-results-reset,
-  test: $_true-results-reset,
-);
-
-
-// Reset
-// -----
-
-/// Reset helper
-/// @access private
-/// @group x_private
-/// @param {String} $scope - Scope to reset
-/// @require $_true-results-reset
-/// @require $_true-results
-@mixin _true-reset(
-  $scope
-) {
-  @if $scope == global {
-    $_true-results: (
-      global: $_true-results-reset,
-      module: $_true-results-reset,
-      test: $_true-results-reset,
-    ) !global;
-  } @else if $scope == module {
-    $update: (
-      module: $_true-results-reset,
-      test: $_true-results-reset,
-    );
-    $_true-results: map-merge($_true-results, $update) !global;
-  } @else if $scope == test {
-    $update: (
-      test: $_true-results-reset
-    );
-    $_true-results: map-merge($_true-results, $update) !global;
-  } @else {
-    @warn "#{$scope} is not a valid scope for _true-reset().";
-  }
-}
-
-
-// Get Results
-// -----------
-
-/// Results getter
-/// @access private
-/// @group x_private
-/// @param {String} $scope - Scope to get results from
-/// @require $_true-results
-@function _true-get-results(
-  $scope
-) {
-  @return map-get($_true-results, $scope);
-}
-
-
-// Get Result
-// ----------
-
-/// Single result getter
-/// @access private
-/// @group x_private
-/// @param {String} $scope - Scope to get result form
-/// @require {function} _true-get-results
-@function _true-get-result(
-  $scope
-) {
-  $results: _true-get-results($scope);
-  $return: if(map-get($results, output-to-css) > 0, output-to-css, null);
-
-  @if map-get($results, fail) > 0 {
-    @return if($return, $return fail, fail);
-  } @else if map-get($results, pass) > 0 {
-    @return if($return, $return pass, pass);
-  } @else {
-    @return $return;
-  }
-}
 
 
 // Update
@@ -107,30 +19,14 @@ $_true-results: (
 /// Update results
 /// @access private
 /// @group x_private
-/// @param {String} $scope - Scope to update results from
-/// @param {List} $results - Results
-/// @require {function} _true-get-results
+/// @param {String} $result - Result (pass/fail/output-to-css)
 /// @require {function} _true-map-increment
 /// @require $_true-results
-@mixin _true-update(
-  $scope,
-  $results
-) {
-  $current: _true-get-results($scope);
-  $update: (run: 1);
-
-  @if $scope == global {
-    $update: _true-get-results(module);
-  } @else {
-    @each $result in $results {
-      @if $result {
-        $update: map-merge($update, ($result: 1));
-      }
-    }
-  }
-
-  $scope: ($scope: _true-map-increment($current, $update));
-  $_true-results: map-merge($_true-results, $scope) !global;
+@mixin _true-update($result) {
+  $_true-results: _true-map-increment($_true-results, (
+    run: 1,
+    $result: 1,
+  )) !global;
 }
 
 
@@ -148,11 +44,10 @@ $_true-results: (
   $scope: test,
   $lines: single
 ) {
-  $results: _true-get-results($scope);
-  $run: map-get($results, run);
-  $pass: map-get($results, pass);
-  $fail: map-get($results, fail);
-  $output-to-css: map-get($results, output-to-css);
+  $run: map-get($_true-results, run);
+  $pass: map-get($_true-results, pass);
+  $fail: map-get($_true-results, fail);
+  $output-to-css: map-get($_true-results, output-to-css);
 
   $items: null;
   $message: null;

--- a/sass/true/_settings.scss
+++ b/sass/true/_settings.scss
@@ -18,11 +18,7 @@ $true-terminal-output: true !default;
 /// @prop {String} module [null]
 /// @prop {String} test [null]
 /// @prop {String} assert [null]
-$_true-context: (
-  module: null,
-  test: null,
-  assert: null,
-);
+$_true-context: ();
 
 /// Update the current context
 /// @access private
@@ -34,7 +30,15 @@ $_true-context: (
   $scope,
   $name
 ) {
-  $_true-context: map-merge($_true-context, ($scope: $name)) !global;
+  $_true-context: append($_true-context, ($scope, $name)) !global;
+}
+
+@mixin _true-context-pop() {
+  $new: ();
+  @for $i from 1 to length($_true-context) {
+    $new: append($new, nth($_true-context, $i));
+  }
+  $_true-context: $new !global;
 }
 
 /// Get information on current context
@@ -45,5 +49,12 @@ $_true-context: (
 @function _true-context(
   $scope
 ) {
-  @return map-get($_true-context, $scope);
+  @for $i from length($_true-context) through 1 {
+    $entry: nth($_true-context, $i);
+    $entry-scope: nth($entry, 1);
+    @if $entry-scope == $scope {
+      @return nth($entry, 2);
+    }
+  }
+  @return null;
 }

--- a/sass/true/_tests.scss
+++ b/sass/true/_tests.scss
@@ -28,13 +28,11 @@
 /// @access private
 /// @group x_private
 /// @param {String} $name - Test name
-/// @require {mixin} _true-reset
 /// @require {mixin} _true-context
 /// @require {mixin} _true-message
 @mixin _true-test-start(
   $name
 ) {
-  @include _true-reset(test);
   @include _true-context(test, $name);
   @include _true-message($name, comments);
 }
@@ -46,12 +44,9 @@
 /// Test stop helper
 /// @access private
 /// @group x_private
-/// @require {mixin} _true-reset
 /// @require {mixin} _true-context
 /// @require {mixin} _true-message
 /// @require {function} _true-get-result
 @mixin _true-test-stop {
-  @include _true-update(module, _true-get-result(test));
-  @include _true-reset(test);
   @include _true-context(test, null);
 }

--- a/sass/true/_tests.scss
+++ b/sass/true/_tests.scss
@@ -48,5 +48,5 @@
 /// @require {mixin} _true-message
 /// @require {function} _true-get-result
 @mixin _true-test-stop {
-  @include _true-context(test, null);
+  @include _true-context-pop();
 }

--- a/test/scss/_messages.scss
+++ b/test/scss/_messages.scss
@@ -9,4 +9,13 @@
     @include assert-equal($return, $expect,
       'Returns a selector string based on the current context');
   }
+  @include test-module('nested') {
+    @include test('True selector') {
+      $return: _true-selector(module test);
+      $expect: '[data-module="Messages"] [data-module="nested"] [data-test="True selector"]';
+
+      @include assert-equal($return, $expect,
+        'Returns a selector string based on a nested context');
+    }
+  }
 }

--- a/test/scss/_modules.scss
+++ b/test/scss/_modules.scss
@@ -3,8 +3,6 @@
 
 @include test-module('Modules') {
   @include test('test-module') {
-    @include assert-equal(map-get($_true-results, module), $_true-results-reset,
-      'Resets module scope results');
     @include assert-equal(_true-context(module), 'Modules',
       'Changes the current module context');
   }

--- a/test/scss/_results.scss
+++ b/test/scss/_results.scss
@@ -2,32 +2,19 @@
 // ===============
 
 @include test-module('Results') {
-  @include test('Reset') {
-    @include assert-true(true,
-      'Add a passing result to the test');
+  @include test('Update with pass') {
+    $before: $_true-results;
+    @include _true-update(pass);
+    $actual: $_true-results;
+    $_true-results: $before !global;
 
-    @include assert-unequal(
-      map-get($_true-results, test),
-      $_true-results-reset,
-      'Check that test results are not in a clean state');
-
-    @include _true-reset(test);
-
-    @include assert-equal(
-      map-get($_true-results, test),
-      $_true-results-reset,
-      'Resets the results for a given scope');
-  }
-
-  @include test('Get results') {
-    @include assert-equal(
-      _true-get-results(module),
-      map-get($_true-results, module),
-      'Returns the current results map for a given scope');
-  }
-
-  @include test('Get result') {
-    @include assert-equal(_true-get-result(module), pass,
-      'Collates a set of results to pass up the scope hierarchy');
+    @include assert-equal(map-get($actual, run), map-get($before, run) + 1,
+      'increments run');
+    @include assert-equal(map-get($actual, pass), map-get($before, pass) + 1,
+      'increments pass');
+    @include assert-equal(map-get($actual, fail), map-get($before, fail),
+      'leaves fails as-is');
+    @include assert-equal(map-get($actual, output-to-css), map-get($before, output-to-css),
+      'leaves output-to-css as-is');
   }
 }

--- a/test/scss/_settings.scss
+++ b/test/scss/_settings.scss
@@ -3,17 +3,17 @@
 
 @include test-module('Settings') {
   @include test('true-context [mixin]') {
-    @include assert-equal(map-get($_true-context, fake), null,
+    @include assert-equal(_true-context(fake), null,
       'Confirm that there is currently no "fake" scope');
 
     @include _true-context(fake, 'this scope is not real');
 
-    @include assert-equal(map-get($_true-context, fake), 'this scope is not real',
+    @include assert-equal(_true-context(fake), 'this scope is not real',
       'Sets the value of scope "fake" to "this scope is not real"');
 
-    $_true-context: map-remove($_true-context, fake);
+    @include _true-context-pop();
 
-    @include assert-equal(map-get($_true-context, fake), null,
+    @include assert-equal(_true-context(fake), null,
       'Confirm that our "fake" scope has been removed');
   }
 

--- a/test/scss/_tests.scss
+++ b/test/scss/_tests.scss
@@ -3,8 +3,6 @@
 
 @include test-module('Tests') {
   @include test('test [mixin]') {
-    @include assert-equal(map-get($_true-results, test), $_true-results-reset,
-      'Resets module scope results');
     @include assert-equal(_true-context(test), 'test [mixin]',
       'Changes the current test context');
   }

--- a/test/test_main.js
+++ b/test/test_main.js
@@ -28,6 +28,7 @@ describe('#parse', function () {
     ].join('\n');
     var expected = [{
       module: "M",
+      modules: [],
       tests: [{
         test: "T",
         assertions: [{
@@ -52,6 +53,7 @@ describe('#parse', function () {
     ].join('\n');
     var expected = [{
       module: "M",
+      modules: [],
       tests: [{
         test: "T",
         assertions: [{
@@ -67,6 +69,33 @@ describe('#parse', function () {
     expect(main.parse(css)).to.deep.equal(expected);
   });
 
+  it('parses a nested passing non-output test', function () {
+    var css = [
+      '[data-module="M"] [data-module="M2"] [data-test="T"] .assert-equal {',
+      '  -result: PASS;',
+      "  -description: 'Desc';",
+      '}'
+    ].join('\n');
+    var expected = [{
+      module: "M",
+      modules: [{
+        module: "M2",
+        modules: [],
+        tests: [{
+          test: "T",
+          assertions: [{
+            description: "Desc",
+            assert: "equal",
+            passed: true,
+          }],
+        }],
+      }],
+      tests: [],
+    }];
+
+    expect(main.parse(css)).to.deep.equal(expected);
+  });
+
   it('handles missing description', function () {
     var css = [
       '[data-module="M"] [data-test="T"] .assert-equal {',
@@ -77,6 +106,7 @@ describe('#parse', function () {
     ].join('\n');
     var expected = [{
       module: "M",
+      modules: [],
       tests: [{
         test: "T",
         assertions: [{
@@ -103,6 +133,7 @@ describe('#parse', function () {
     ].join('\n');
     var expected = [{
       module: "M",
+      modules: [],
       tests: [{
         test: "T",
         assertions: [{
@@ -129,6 +160,7 @@ describe('#parse', function () {
     ].join('\n');
     var expected = [{
       module: "M",
+      modules: [],
       tests: [{
         test: "T",
         assertions: [{
@@ -157,6 +189,7 @@ describe('#parse', function () {
     ].join('\n');
     var expected = [{
       module: "M",
+      modules: [],
       tests: [{
         test: "T",
         assertions: [{
@@ -184,6 +217,7 @@ describe('#parse', function () {
     ].join(' ');
     var expected = [{
       module: "M",
+      modules: [],
       tests: [{
         test: "T",
         assertions: [{
@@ -214,7 +248,7 @@ describe('#parseSelector', function () {
     var sel = '[data-module="M"] [data-test="T"] .assert-equal';
     var exp = {
       output: false,
-      module: "M",
+      modules: ["M"],
       test: "T",
       assert: "equal",
     };
@@ -226,7 +260,7 @@ describe('#parseSelector', function () {
     var sel = '[data-module="M 1"] [data-test="T 2"] .assert-equal';
     var exp = {
       output: false,
-      module: "M 1",
+      modules: ["M 1"],
       test: "T 2",
       assert: "equal",
     };
@@ -238,7 +272,7 @@ describe('#parseSelector', function () {
     var sel = '[data-module="M"] [data-test="T"] [data-assert="A"] .input';
     var exp = {
       output: true,
-      module: "M",
+      modules: ["M"],
       test: "T",
       assert: "A",
       type: 'input',


### PR DESCRIPTION
*Fixes #32*

I implemented nested modules.

I had to change a lot of code, but I tried to keep the changes minimal. Most importantly, the public API is fully backwards compatible.

Note that I simplified the results module quite a bit. As far as I could see, per-test results were never used, so they just added complexity without being useful.

I guess this conflicts with some other pull requests, epecially #51. I would happily help with merging.

**Note**: I only tested with node-sass.