### PR TITLE
Parse an assertion without a description.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -147,12 +147,12 @@ var parseTest = function (rule, ctx) {
 
 var parseAssertion = function (rule, ctx) {
   if (rule.type === 'comment') {
-    var text = rule.comment.trim();
+    var text = rule.comment.trimLeft();
     if (!text) { return parseAssertion; }
     if (startsWith(text, PASS_TOKEN)) {
       finishCurrentAssertion(ctx);
       ctx.currentAssertion = {
-        description: text.substring(PASS_TOKEN.length),
+        description: text.substring(PASS_TOKEN.length).trim() || '<no description>',
         passed: true
       };
       return parseAssertion;
@@ -162,13 +162,13 @@ var parseAssertion = function (rule, ctx) {
       ctx.currentAssertion = {
         description: text.substring(endAssertionType + 2).trim(),
         passed: false,
-        assertionType: text.substring(FAIL_TOKEN.length, endAssertionType),
+        assertionType: text.substring(FAIL_TOKEN.length, endAssertionType).trim(),
       };
       return parseFailureDetail;
     } else if (startsWith(text, ASSERT_TOKEN)) {
       finishCurrentAssertion(ctx);
       ctx.currentAssertion = {
-        description: text.substring(ASSERT_TOKEN.length),
+        description: text.substring(ASSERT_TOKEN.length).trim(),
         assertionType: 'equal'
       };
       return parseAssertionOutputStart;

--- a/test/test_main.js
+++ b/test/test_main.js
@@ -70,6 +70,7 @@ describe('#parse', function () {
 
     expect(main.parse(css)).to.deep.equal(expected);
   });
+
   it('ignores a summary', function () {
     var css = [
       '/* # SUMMARY ---------- */',
@@ -83,6 +84,28 @@ describe('#parse', function () {
 
     expect(main.parse(css)).to.deep.equal(expected);
   });
+
+  it('parses a passing non-output test sans description', function () {
+    var css = [
+      '/* # Module: Utilities */',
+      '/* ------------------- */',
+      '/* Test: Map Add [function] */',
+      '/*   ✔ */'
+    ].join('\n');
+    var expected = [{
+      module: "Utilities",
+      tests: [{
+        test: "Map Add [function]",
+        assertions: [{
+          description: "<no description>",
+          passed: true,
+        }],
+      }],
+    }];
+
+    expect(main.parse(css)).to.deep.equal(expected);
+  });
+
 
   it('parses a test following a summary', function () {
     var css = [


### PR DESCRIPTION
I made the default description `<no description>` rather than empty string; I think the latter is confusing in the Mocha output.