### PR TITLE
Add mixin counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,19 @@ Asserts that two parameters are unequal.
     @include assert-unequal($test, 10, 'Your assert description');
   }
 ```
+
+### Summary
+
+Reports show a summary of total, passed, failed, and output to CSS tests. The summary can be output into CSS and/or onto the terminal. If you use Mocha, reporting to the command line is automatic. If you use true-cli, `@include report(terminal)` is required at the end of your main test file for output.
+
+#### `@include report()`
+
+Reports summary and stats data into CSS and/or onto the terminal.
+
+- `@param` {`Bool`} `$terminal` [`true`] - Optionally output results to the terminal,
+- `@param` {`Bool`} `$fail-on-error` [`false`] - Optionally error out the compiler if tests have failed
+- `@param` {`Bool`} `$stats` [`true`] - Optionally output number of modules, tests, and assertions found
+
+```scss
+  @include report($terminal: true, $stats: true);
+```

--- a/README.md
+++ b/README.md
@@ -318,10 +318,9 @@ Reports show a summary of total, passed, failed, and output to CSS tests. The su
 
 Reports summary and stats data into CSS and/or onto the terminal.
 
-- `@param` {`Bool`} `$terminal` [`true`] - Optionally output results to the terminal,
+- `@param` {`Bool`} `$terminal` [`true`] - Optionally output results to the terminal
 - `@param` {`Bool`} `$fail-on-error` [`false`] - Optionally error out the compiler if tests have failed
-- `@param` {`Bool`} `$stats` [`false`] - Optionally output number of modules, tests, and assertions found
 
 ```scss
-  @include report($terminal: true, $stats: true);
+  @include report();
 ```

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Reports summary and stats data into CSS and/or onto the terminal.
 
 - `@param` {`Bool`} `$terminal` [`true`] - Optionally output results to the terminal,
 - `@param` {`Bool`} `$fail-on-error` [`false`] - Optionally error out the compiler if tests have failed
-- `@param` {`Bool`} `$stats` [`true`] - Optionally output number of modules, tests, and assertions found
+- `@param` {`Bool`} `$stats` [`false`] - Optionally output number of modules, tests, and assertions found
 
 ```scss
   @include report($terminal: true, $stats: true);

--- a/bin/true-cli
+++ b/bin/true-cli
@@ -59,8 +59,9 @@ output = with_captured_stdout do
   end
 end
 
+matches = output.match(%r{(?<tests>\d+) Tests?, (?<passed>\d+) Passed, (?<failed>\d+) Failed})
+stats_matches = output.match(%r{(?<modules>\d+) Modules?, (?<tests>\d+) Tests?, (?<assertions>\d+) Assertions?})
 
-matches = output.match(%r{(?<tests>\d+) Tests, (?<passed>\d+) Passed, (?<failed>\d+) Failed})
 if matches.nil? # return sass errors
   puts output
   exit(2)
@@ -68,10 +69,15 @@ end
 
 if matches[:failed] == '0'
   if options['color']
-    noun = matches[:tests].to_i == 1 ? 'Test' : 'Tests'
-    puts COLORS[:ok] + "#{matches[:tests]} #{noun}, #{matches[:passed]} Passed, #{matches[:failed]} Failed" + COLORS[:end] unless options['silent']
+    unless options['silent']
+      puts COLORS[:ok] + matches.to_s + COLORS[:end]
+      puts COLORS[:ok] + stats_matches.to_s + COLORS[:end]
+    end
   else
-    puts output unless options['silent']
+    unless options['silent']
+      puts matches
+      puts stats_matches
+    end
   end
   exit(0)
 else

--- a/sass/true/_assert.scss
+++ b/sass/true/_assert.scss
@@ -117,6 +117,7 @@
   @content;
 
   @include _true-update-test('output-to-css');
+  @include _true-update-stats-count('assertions');
   @include _true-context-pop();
   @include _true-message('  END_ASSERT  ', 'comments');
 }
@@ -223,5 +224,6 @@
   }
 
   @include _true-update-test($result);
+  @include _true-update-stats-count('assertions');
   @include _true-context-pop();
 }

--- a/sass/true/_modules.scss
+++ b/sass/true/_modules.scss
@@ -49,6 +49,7 @@
 /// Module stop helper
 /// @access private
 @mixin _true-module-stop {
+  @include _true-update-stats-count('modules');
   @include _true-context-pop();
   @include _true-message('', 'comments');
 }

--- a/sass/true/_results.scss
+++ b/sass/true/_results.scss
@@ -12,12 +12,9 @@
 ///   Optionally output results to the terminal
 /// @param {Bool} $fail-on-error [false] -
 ///   Optionally error out the compiler if tests have failed
-/// @param {Bool} $stats [false] -
-///   Optionally output number of modules, tests, and assertions found
 @mixin report(
   $terminal: $true-terminal-output,
-  $fail-on-error: false,
-  $stats: true
+  $fail-on-error: false
 ) {
   $message: _true-report-message('global', 'multiple');
   $stats-message: _true-stats-message($_true-stats-count, 'multiple');

--- a/sass/true/_results.scss
+++ b/sass/true/_results.scss
@@ -17,9 +17,10 @@
 @mixin report(
   $terminal: $true-terminal-output,
   $fail-on-error: false,
-  $stats: false
+  $stats: true
 ) {
   $message: _true-report-message('global', 'multiple');
+  $stats-message: _true-stats-message($_true-stats-count, 'multiple');
 
   $fail: map-get($_true-results, 'fail');
   @if $fail-on-error and ($fail > 0) {
@@ -28,17 +29,17 @@
 
   @include _true-message('# SUMMARY ----------', 'comments');
   @include _true-message($message, 'comments');
+  @include _true-message($stats-message, 'comments');
   @include _true-message('--------------------', 'comments');
 
   @if $terminal {
     $message: _true-report-message('global', 'single');
     @include _true-message($message, 'debug');
+
+    $stats-message: _true-stats-message($_true-stats-count, 'single');
+    @include _true-message($stats-message, 'debug');
   }
 
-  @if $stats {
-    $message: _true-stats-message();
-    @include _true-message($message, 'debug');
-  }
 }
 
 
@@ -103,7 +104,8 @@ $_true-test-result: null;
 /// Report message
 /// @access private
 /// @param {String} $scope [test] - Scope
-/// @param {String} $lines [single] - Lines
+/// @param {String} $lines [single] -
+///   Return message either as a single line or in multiple lines
 /// @return {String} - Reported message
 @function _true-report-message(
   $scope: 'test',
@@ -118,9 +120,9 @@ $_true-test-result: null;
   $message: null;
 
   @if $scope == 'global' or $scope == 'module' {
-    $items: 'Tests';
+    $items: if($run == 1, 'Test', 'Tests');
   } @else if $scope == 'test' {
-    $items: 'Assertions';
+    $items: if($run == 1, 'Assertion', 'Assertions');
   }
 
   @if $lines == 'single' {
@@ -136,9 +138,9 @@ $_true-test-result: null;
 
 // Stats Count
 // -----------
-/// Global stats count
+/// Global stats count of how many modules, tests, and assertions are found
 /// @access private
-/// @type Map<Number>
+/// @type Map<String: Number>
 $_true-stats-count: (
   'modules': 0,
   'tests': 0,
@@ -153,13 +155,7 @@ $_true-stats-count: (
 /// @param {String} $type - The stats type to add to
 /// @access private
 @mixin _true-update-stats-count($type) {
-  @if index(map-keys($_true-stats-count), $type) {
-    $new-count: map-get($_true-stats-count, $type) + 1;
-    $new-count-map: ($type: $new-count);
-    $_true-stats-count: map-merge($_true-stats-count, ($type: $new-count)) !global;
-  } @else {
-    @warn '\'#{$type}\' statistic type does not exist.';
-  }
+  $_true-stats-count: _true-map-increment($_true-stats-count, ($type: 1)) !global;
 }
 
 
@@ -168,15 +164,30 @@ $_true-stats-count: (
 // -------------
 /// Stats message
 /// @access private
-/// @return {String} - Stats debug message
-@function _true-stats-message($stats: $_true-stats-count) {
+/// @param {Map<String: Number>} $stats [$_true-stats-count] -
+///   Map that contains the stats counts for modules, tests, and assertions found
+/// @param {String} $lines [single] -
+///   Return message either as a single line or in multiple lines
+/// @return {String} - Stats count message
+@function _true-stats-message(
+  $stats: $_true-stats-count,
+  $lines: 'single'
+) {
   $message: null;
 
   $modules: map-get($stats, 'modules');
   $tests: map-get($stats, 'tests');
   $assertions: map-get($stats, 'assertions');
 
-  $message: '#{$modules} Modules, #{$tests} Tests, #{$assertions} Assertions';
+  $modules-label: if($modules == 1, 'Module', 'Modules');
+  $tests-label: if($tests == 1, 'Test', 'Tests');
+  $assertions-label: if($assertions == 1, 'Assertion', 'Assertions');
+
+  @if $lines == 'single' {
+    $message: '#{$modules} #{$modules-label}, #{$tests} #{$tests-label}, #{$assertions} #{$assertions-label}';
+  } @else {
+    $message: 'Stats: #{$_tnl} - #{$modules} #{$modules-label} #{$_tnl} - #{$tests} #{$tests-label} #{$_tnl} - #{$assertions} #{$assertions-label}';
+  }
 
   @return $message;
 }

--- a/sass/true/_results.scss
+++ b/sass/true/_results.scss
@@ -12,12 +12,12 @@
 ///   Optionally output results to the terminal
 /// @param {Bool} $fail-on-error [false] -
 ///   Optionally error out the compiler if tests have failed
-/// @param {Bool} $stats [true] -
+/// @param {Bool} $stats [false] -
 ///   Optionally output number of modules, tests, and assertions found
 @mixin report(
   $terminal: $true-terminal-output,
   $fail-on-error: false,
-  $stats: true
+  $stats: false
 ) {
   $message: _true-report-message('global', 'multiple');
 

--- a/sass/true/_results.scss
+++ b/sass/true/_results.scss
@@ -11,10 +11,13 @@
 /// @param {Bool} $terminal [$true-terminal-output] -
 ///   Optionally output results to the terminal
 /// @param {Bool} $fail-on-error [false] -
-///   Optionally error out of the compiler if tests have failed
+///   Optionally error out the compiler if tests have failed
+/// @param {Bool} $stats [true] -
+///   Optionally output number of modules, tests, and assertions found
 @mixin report(
   $terminal: $true-terminal-output,
-  $fail-on-error: false
+  $fail-on-error: false,
+  $stats: true
 ) {
   $message: _true-report-message('global', 'multiple');
 
@@ -29,6 +32,11 @@
 
   @if $terminal {
     $message: _true-report-message('global', 'single');
+    @include _true-message($message, 'debug');
+  }
+
+  @if $stats {
+    $message: _true-stats-message();
     @include _true-message($message, 'debug');
   }
 }
@@ -122,6 +130,53 @@ $_true-test-result: null;
     $message: '#{$run $items}:#{$_tnl} - #{$pass} Passed#{$_tnl} - #{$fail} Failed';
     $message: if($output-to-css > 0, $message + '#{$_tnl} - #{$output-to-css} Output to CSS', $message);
   }
+
+  @return $message;
+}
+
+// Stats Count
+// -----------
+/// Global stats count
+/// @access private
+/// @type Map<Number>
+$_true-stats-count: (
+  'modules': 0,
+  'tests': 0,
+  'assertions': 0
+);
+
+
+
+// Update stats count
+// ------------------
+/// Add to a stats count type count by 1
+/// @param {String} $type - The stats type to add to
+/// @access private
+@mixin _true-update-stats-count($type) {
+  @if index(map-keys($_true-stats-count), $type) {
+    $new-count: map-get($_true-stats-count, $type) + 1;
+    $new-count-map: ($type: $new-count);
+    $_true-stats-count: map-merge($_true-stats-count, ($type: $new-count)) !global;
+  } @else {
+    @warn '\'#{$type}\' statistic type does not exist.';
+  }
+}
+
+
+
+// Stats Message
+// -------------
+/// Stats message
+/// @access private
+/// @return {String} - Stats debug message
+@function _true-stats-message($stats: $_true-stats-count) {
+  $message: null;
+
+  $modules: map-get($stats, 'modules');
+  $tests: map-get($stats, 'tests');
+  $assertions: map-get($stats, 'assertions');
+
+  $message: '#{$modules} Modules, #{$tests} Tests, #{$assertions} Assertions';
 
   @return $message;
 }

--- a/sass/true/_tests.scss
+++ b/sass/true/_tests.scss
@@ -40,6 +40,7 @@
 /// @access private
 @mixin _true-test-stop {
   @include _true-update($_true-test-result);
+  @include _true-update-stats-count('tests');
   @include _true-context-pop();
   @include _true-message('', 'comments');
 }

--- a/test/css/test.css
+++ b/test/css/test.css
@@ -187,8 +187,12 @@
 /*  */
 /*  */
 /* # SUMMARY ---------- */
-/* 25 Tests: */
-/*  - 21 Passed */
+/* 29 Tests: */
+/*  - 25 Passed */
 /*  - 0 Failed */
 /*  - 4 Output to CSS */
+/* Stats: */
+/*  - 15 Modules */
+/*  - 29 Tests */
+/*  - 38 Assertions */
 /* -------------------- */

--- a/test/scss/_results.scss
+++ b/test/scss/_results.scss
@@ -1,5 +1,5 @@
-// Test Assertions
-// ===============
+// Test Results
+// ============
 
 @include test-module('Update Results') {
   @include test('Update global results with pass') {
@@ -24,5 +24,45 @@
       map-get($actual, 'output-to-css'),
       map-get($before, 'output-to-css'),
       'leaves output-to-css as-is');
+  }
+}
+
+@include test-module('Stats') {
+  @include test('Count updates') {
+    $before: $_true-stats-count;
+    @include _true-update-stats-count('assertions');
+    $actual: $_true-stats-count;
+    $_true-stats-count: $before !global;
+
+    @include assert-equal(
+      map-get($actual, 'assertions'),
+      map-get($before, 'assertions') + 1,
+      'assertions counts is updated'
+    );
+
+    @include assert-equal(
+      map-get($actual, 'modules'),
+      map-get($before, 'modules'),
+      'leaves modules counts is as-is'
+    );
+
+    @include assert-equal(
+      map-get($actual, 'tests'),
+      map-get($before, 'tests'),
+      'tests counts is updated'
+    );
+  }
+
+  @include test('Stats message creation') {
+    $test-map: (
+      'modules': 4,
+      'tests': 6,
+      'assertions': 25
+    );
+
+    $actual-message: _true-stats-message($test-map);
+    $expected-message: '4 Modules, 6 Tests, 25 Assertions';
+
+    @include assert-equal($actual-message, $expected-message);
   }
 }

--- a/test/scss/test.scss
+++ b/test/scss/test.scss
@@ -11,4 +11,4 @@
 @import 'tests';
 @import 'assert';
 
-@include report('terminal');
+@include report('terminal', $stats: true);

--- a/test/scss/test.scss
+++ b/test/scss/test.scss
@@ -11,4 +11,4 @@
 @import 'tests';
 @import 'assert';
 
-@include report('terminal', $stats: true);
+@include report('terminal');

--- a/test/scss/test.scss
+++ b/test/scss/test.scss
@@ -11,4 +11,4 @@
 @import 'tests';
 @import 'assert';
 
-@include report('terminal');
+@include report();


### PR DESCRIPTION
**Closes #57:** Add an additional option in the report mixin to output counts of total modules, test, and assertions found.

I know the issue was asking for number of assertions, but I figured that expanding out to modules and tests would be just as useful and more robust than just assertions. If you agree with this thought, I wonder if also counting and outputting `output` and `expect` usages would be useful as well.

I also updated the README docs to reflect the change.


