### PR TITLE
fix eyeglass compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "mocha-istanbul": "^0.2.0"
   },
   "eyeglass": {
-    "needs": "^0.8.2",
+    "needs": "^1.0",
     "name": "true",
+    "sassDir": "./sass/",
     "exports": false
   },
   "scripts": {


### PR DESCRIPTION
This includes two changes:
- bump eyeglass `needs` to `^1.0` (this has no functional impact, but will avoid warnings for consumers using latest eyeglass)
- adds the `sassDir` configuration so that eyeglass can correctly resolve `@import "true"` (this is critical; without this, `true` will not work as an eyeglass module)

Related: sass-eyeglass/eyeglass/issues/164