### PR TITLE
Inspect Everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 True Changelog
 ==============
 
+
+2.2.3 (unreleased)
+------------------
+- Changes to equality-comparisons,
+  and how they differ from the Sass ``==`` comparison...
+  - [CHANGED] We allow single-item and empty lists to ignore delimiters
+    so that `join((), 'test') == ('test',)` since they have the same output
+  - [CHANGED] Rounded values (numbers & colors) are compared after rounding
+    so that `1/3 == 0.33333333`
+    (previously didn't include colors)
+  - [unchanged] We still insist that numbers have the same units,
+    not just comparable values
+  - [unchanged] We still compare variable-types
+    in addition to output values
+    because that distinction is important for most Sass tools
+    (`1em + 1em == 2em` while `"1em" + "1em" == "1em1em"`)
+
+
 2.2.2 (4/11/17)
 ---------------
 - `assert-true` returns false on empty strings and lists

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "http://rubygems.org"
 
 gemspec
+gem 'rake'

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "test": "rm -rf coverage && ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -R spec",
     "debug": "./node_modules/.bin/mocha -R spec debug",
+    "commit": "npm test; rake test; sassdoc sass/",
     "compile": "./node_modules/.bin/node-sass test/scss/test.scss test/css/test.css --include-path ./sass/",
     "coverage-html": "./node_modules/.bin/istanbul report html"
   },

--- a/sass/true/_utilities.scss
+++ b/sass/true/_utilities.scss
@@ -91,21 +91,35 @@
 
 // Is Equal
 // --------
-/// Check for equality, excluding comparable numbers
+/// Check for equality, with a few changes from the Sass ``==`` comparison.
+/// - We allow single-item and empty lists to ignore delimiters
+///   so that `join((), 'test') == ('test',)` since they have the same output
+/// - Rounded values (number & colors) are compared after rounding
+///   so that `1/3 == 0.33333333`
+/// - We insist that numbers have the same units,
+///   not just comparable values
+/// - Like Sass, we still compare variable-types in addition to output values
+///   because that distinction is important for most Sass tools
+///   (`1em + 1em == 2em` while `"1em" + "1em" == "1em1em"`)
 /// @access private
 /// @param {*} $one -
-///   First value
+///   First value for comparison
 /// @param {*} $two -
-///   Second value
+///   Second value for comparison
 /// @return {Bool}
 @function _true-is-equal($one, $two) {
-  @if type-of($one) == 'number' and type-of($two) == 'number' {
-    @if unit($one) == unit($two) {
-      @return inspect($one) == inspect($two);
-    } @else {
-      @return false;
+  $type-one: type-of($one);
+  $type-two: type-of($two);
+
+  @if $type-one == $type-two {
+    // force short lists to use the same separator
+    @if ($type-one == 'list') {
+      $one: if(length($one) < 2, join((), $one, space), $one);
+      $two: if(length($two) < 2, join((), $two, space), $two);
     }
-  } @else {
-    @return $one == $two;
+
+    @return inspect($one) == inspect($two);
   }
+
+  @return false;
 }

--- a/test/css/test.css
+++ b/test/css/test.css
@@ -40,11 +40,23 @@
 /* Test: Mismatched units */
 /*   ✔ Returns false for equal numbers with different units. */
 /*  */
+/* Test: Mismatched types */
+/*   ✔ Returns false for equal values with different data types. */
+/*  */
 /* Test: Adding floats */
 /*   ✔ 0.1 + 0.2 should equal .3. */
 /*  */
 /* Test: Rounded numbers with division */
 /*   ✔ 1/3 should equal .33333. */
+/*  */
+/* Test: Single-item lists */
+/*   ✔ Delimiters are ignored in single-item lists. */
+/*  */
+/* Test: Multi-item lists */
+/*   ✔ 1/3 should equal .33333. */
+/*  */
+/* Test: Rounded Colors */
+/*   ✔ Rounded colors match their output. */
 /*  */
 /*  */
 /* # Module: True Message */
@@ -204,12 +216,12 @@
 /*  */
 /*  */
 /* # SUMMARY ---------- */
-/* 29 Tests: */
-/*  - 25 Passed */
+/* 33 Tests: */
+/*  - 29 Passed */
 /*  - 0 Failed */
 /*  - 4 Output to CSS */
 /* Stats:  */
 /*  - 15 Modules  */
-/*  - 29 Tests  */
-/*  - 38 Assertions */
+/*  - 33 Tests  */
+/*  - 42 Assertions */
 /* -------------------- */

--- a/test/scss/_utilities.scss
+++ b/test/scss/_utilities.scss
@@ -22,7 +22,7 @@
 
   @include test('String Join [function]') {
     @include assert-equal(
-      _true-str-join(one two three, '%s'),
+      _true-str-join('one' 'two' 'three', '%s'),
       'one%stwo%sthree',
       'Returns a single string, based on any delimiter.');
   }
@@ -42,6 +42,12 @@
       'Returns false for equal numbers with different units.');
   }
 
+  @include test('Mismatched types') {
+    @include assert-false(
+      _true-is-equal(unquote('1rem'), 1rem),
+      'Returns false for equal values with different data types.');
+  }
+
   @include test('Adding floats') {
     @include assert-true(
       _true-is-equal(0.1 + 0.2, 0.3),
@@ -52,5 +58,29 @@
     @include assert-true(
       _true-is-equal(1/3, 0.333333),
       '1/3 should equal .33333.');
+  }
+
+  @include test('Single-item lists') {
+    $one: join((), 'test', space);
+    $two: join((), 'test', comma);
+
+    @include assert-true(
+      _true-is-equal($one, $two),
+      'Delimiters are ignored in single-item lists.');
+  }
+
+  @include test('Multi-item lists') {
+    $one: join('test', 'test', space);
+    $two: join('test', 'test', comma);
+
+    @include assert-false(
+      _true-is-equal($one, $two),
+      '1/3 should equal .33333.');
+  }
+
+  @include test('Rounded Colors') {
+    @include assert-true(
+      _true-is-equal(#3b3b3b, lighten(#333, 3.125%)),
+      'Rounded colors match their output.');
   }
 }


### PR DESCRIPTION
Resolves #84 

- [CHANGED] We allow single-item and empty lists to ignore delimiters so that `join((), 'test') == ('test',)` since they have the same output
- [CHANGED] Rounded values (numbers & colors) are compared after rounding so that `1/3 == 0.33333333` (previously didn't include colors)
- [unchanged] We still insist that numbers have the same units, not just comparable values
- [unchanged] We still compare variable-types in addition to output values because that distinction is important for most Sass tools (`1em + 1em == 2em` while `"1em" + "1em" == "1em1em"`)
