### PR TITLE
[output-errors] Throw errors on badly-formed output tests

### DIFF
--- a/.sassdocrc
+++ b/.sassdocrc
@@ -1,2 +1,11 @@
 theme: 'herman'
 dest: gh-pages/sassdoc
+
+autofill:
+  - throw
+  - content
+  - require
+
+groups:
+  private-context: Context (private)
+

--- a/sass/true/_assert.scss
+++ b/sass/true/_assert.scss
@@ -139,7 +139,7 @@
   @include _true-output-context(null);
   @include _true-update-test('output-to-css');
   @include _true-update-stats-count('assertions');
-  @include _true-context-pop();
+  @include _true-context-pop;
   @include _true-message('  END_ASSERT  ', 'comments');
 }
 
@@ -235,7 +235,7 @@
 
   @include _true-update-test($result);
   @include _true-update-stats-count('assertions');
-  @include _true-context-pop();
+  @include _true-context-pop;
 }
 
 
@@ -250,9 +250,10 @@
 @function _true-is-truthy(
   $assert
 ) {
-  $truthy: if(
-    (not not $assert) and ($assert != '') and ($assert != ()),
-    true, false);
+  $not: (not not $assert);
+  $list: ($assert != ());
+  $string: ($assert != '');
+  $truthy: if(($not and $list and $string), true, false);
 
   @return $truthy;
 }

--- a/sass/true/_assert.scss
+++ b/sass/true/_assert.scss
@@ -158,7 +158,6 @@
 @mixin output(
   $selector: true
 ) {
-  @include _true-context-or-error;
   @include _true-output-context('output');
   @include _true-message('  OUTPUT  ', 'comments');
 
@@ -188,7 +187,6 @@
 @mixin expect(
   $selector: true
 ) {
-  @include _true-context-or-error;
   @include _true-output-context('expect');
   @include _true-message('  EXPECTED  ', 'comments');
 

--- a/sass/true/_assert.scss
+++ b/sass/true/_assert.scss
@@ -130,11 +130,13 @@
   $description: null
 ) {
   $default: _true-context('test');
+  @include _true-output-context('assert');
   @include _true-context('assert', '[output] #{$description or $default}');
   @include _true-message('  ASSERT: #{$description}  ', 'comments');
 
   @content;
 
+  @include _true-output-context(null);
   @include _true-update-test('output-to-css');
   @include _true-update-stats-count('assertions');
   @include _true-context-pop();
@@ -156,6 +158,8 @@
 @mixin output(
   $selector: true
 ) {
+  @include _true-context-or-error;
+  @include _true-output-context('output');
   @include _true-message('  OUTPUT  ', 'comments');
 
   @if $selector {
@@ -184,6 +188,8 @@
 @mixin expect(
   $selector: true
 ) {
+  @include _true-context-or-error;
+  @include _true-output-context('expect');
   @include _true-message('  EXPECTED  ', 'comments');
 
   @if $selector {

--- a/sass/true/_context.scss
+++ b/sass/true/_context.scss
@@ -46,6 +46,47 @@ $_true-context: ();
 
 
 
+// Output-context [variable]
+// -------------------------
+$_true-output-context: ();
+
+
+
+// Output-context [mixin]
+// ----------------------
+@mixin _true-output-context(
+  $new
+) {
+  @if index($_true-output-context, $new) {
+    @if ($new == 'assert') {
+      @error 'The `assert()` mixin can not contain another `assert()`';
+    }
+
+    @error 'The `#{$new}()` mixin must only be used once per `assert()`';
+  } @else if $new {
+    $_true-output-context: append($_true-output-context, $new) !global;
+  } @else {
+    $length: length($_true-output-context);
+    $has-both: index($_true-output-context, 'output') and index($_true-output-context, 'expect');
+
+    @if ($length != 3) or (not $has-both) {
+      @error 'Each `assert()` must contain one `output()` and one `expect()`';
+    }
+
+    $_true-output-context: () !global;
+  }
+}
+
+
+// Context-or-error [mixin]
+// ------------------------
+@mixin _true-context-or-error {
+  @if not index($_true-output-context, 'assert') {
+    @error 'The `assert()` wrapper is required for `output()` and `expect()`';
+  }
+}
+
+
 // Context [function]
 // ------------------
 /// Get information on current context for a given scope

--- a/sass/true/_context.scss
+++ b/sass/true/_context.scss
@@ -7,7 +7,7 @@
 // ------------------
 /// True current context
 /// @access private
-/// @group private
+/// @group private-context
 /// @type list
 $_true-context: ();
 
@@ -17,7 +17,7 @@ $_true-context: ();
 // ---------------
 /// Update the current context for a given scope
 /// @access private
-/// @group private
+/// @group private-context
 /// @param {String} $scope - Either `module`, `test` or `assert`
 /// @param {String} $name - Name of current scope
 @mixin _true-context(
@@ -33,7 +33,7 @@ $_true-context: ();
 // -------------------
 /// Remove the deepest context layer
 /// @access private
-/// @group private
+/// @group private-context
 @mixin _true-context-pop {
   $new: ();
 
@@ -48,15 +48,38 @@ $_true-context: ();
 
 // Output-context [variable]
 // -------------------------
+/// Make sure every output test includes an `assert`, `output`, and `expect`
+/// @access private
+/// @group private-context
+/// @type list
 $_true-output-context: ();
 
 
 
 // Output-context [mixin]
 // ----------------------
+/// Add `assert`, `output`, or `expect` context to an output test,
+/// or check to make sure they all exist before resetting the context.
+/// @access private
+/// @group private-context
+/// @param {'assert' | 'output' | 'expect' | null} $new -
+///   Add a new `assert`, `output`, or `expect` layer
+///   to the context of an output-test,
+///   or use `null` to check that all context is properly formed
+///   and then reset it at the end of a test
+/// @throw Error when adding unknown context
+/// @throw Error when trying to add context that already exists
+/// @throw Error when `assert()` is missing before `expect` or `output`
+/// @throw Error when context is missing before a reset
 @mixin _true-output-context(
   $new
 ) {
+  $valid: 'assert' 'expect' 'output';
+
+  @if $new and not (index($valid, $new)) {
+    @error '#{$new} is not a valid context for output tests: #{$valid}';
+  }
+
   @if index($_true-output-context, $new) {
     @if ($new == 'assert') {
       @error 'The `assert()` mixin can not contain another `assert()`';
@@ -64,6 +87,10 @@ $_true-output-context: ();
 
     @error 'The `#{$new}()` mixin must only be used once per `assert()`';
   } @else if $new {
+    @if index('expect' 'output', $new) and not index($_true-output-context, 'assert') {
+      @error 'The `assert()` wrapper is required for `output()` and `expect()`';
+    }
+
     $_true-output-context: append($_true-output-context, $new) !global;
   } @else {
     $length: length($_true-output-context);
@@ -78,20 +105,11 @@ $_true-output-context: ();
 }
 
 
-// Context-or-error [mixin]
-// ------------------------
-@mixin _true-context-or-error {
-  @if not index($_true-output-context, 'assert') {
-    @error 'The `assert()` wrapper is required for `output()` and `expect()`';
-  }
-}
-
-
 // Context [function]
 // ------------------
 /// Get information on current context for a given scope
 /// @access private
-/// @group private
+/// @group private-context
 /// @param {String} $scope
 /// @return {String}
 @function _true-context(
@@ -114,7 +132,7 @@ $_true-output-context: ();
 // ----------------------
 /// Get list of context names for a given scope
 /// @access private
-/// @group private
+/// @group private-context
 /// @param {String} $scope
 /// @return {List}
 @function _true-context-all(

--- a/sass/true/_output.scss
+++ b/sass/true/_output.scss
@@ -73,6 +73,10 @@
     $type: '#{list-separator($var)}-#{$type}';
   }
 
+  @if ($type == 'string') and ($var != unquote($var)) {
+    $type: 'quoted-#{$type}';
+  }
+
   @return '[#{$type}] #{$inspect}';
 }
 
@@ -102,7 +106,18 @@
   }
 
 
-  @if inspect($one) == inspect($two) {
+  // String Quotes
+  @if ($one-type == 'string') and ($two-type == 'string')  {
+    @if (unquote($one) == unquote($two)) {
+      $message: 'string quotations do not match';
+      $note: $pre + $message;
+    }
+  }
+
+  $one: if(($one-type == 'string'), unquote($one), $one);
+  $two: if(($two-type == 'string'), unquote($two), $two);
+
+  @if (inspect($one) == inspect($two)) {
     // Type
     @if ($one-type != $two-type) {
       $message: 'variable types do not match';

--- a/test/css/test.css
+++ b/test/css/test.css
@@ -91,6 +91,18 @@
 /*  */
 /*  */
 /*  */
+/* # Module: true-output-context [mixin] */
+/* ------------------------------------- */
+/* Test: Appends new context */
+/*   ✔ [assert-equal] Check initial value */
+/*   ✔ [assert-equal] Appends new context */
+/*   ✔ [assert-equal] Appends new context */
+/*   ✔ [assert-equal] Appends new context */
+/*  */
+/* Test: Resets context */
+/*   ✔ [assert-equal] Resets context */
+/*  */
+/*  */
 /* # Module: Get Result */
 /* -------------------- */
 /* Test: Equal Pass */
@@ -378,12 +390,12 @@
 /*  */
 /*  */
 /* # SUMMARY ---------- */
-/* 70 Tests: */
-/* - 64 Passed */
+/* 72 Tests: */
+/* - 66 Passed */
 /* - 0 Failed */
 /* - 6 Output to CSS */
 /* Stats: */
-/* - 25 Modules */
-/* - 70 Tests */
-/* - 78 Assertions */
+/* - 26 Modules */
+/* - 72 Tests */
+/* - 83 Assertions */
 /* -------------------- */

--- a/test/scss/_assert.scss
+++ b/test/scss/_assert.scss
@@ -106,7 +106,8 @@
   @include test('Adding floats') {
     @include assert-equal(
       0.1 + 0.2,
-      0.3);
+      0.3,
+      $inspect: true);
   }
 
   @include test('Rounded numbers with $inspect') {

--- a/test/scss/_context.scss
+++ b/test/scss/_context.scss
@@ -62,3 +62,51 @@
     }
   }
 }
+
+
+// Output context
+@include test-module('true-output-context [mixin]') {
+  $empty-list: ();
+  $before: $_true-output-context;
+  @include _true-output-context('assert');
+  $assert: $_true-output-context;
+  @include _true-output-context('expect');
+  $expect: $_true-output-context;
+  @include _true-output-context('output');
+  $output: $_true-output-context;
+  @include _true-output-context(null);
+  $reset: $_true-output-context;
+
+  @include test('Appends new context') {
+    @include assert-equal(
+      $before,
+      $empty-list,
+      'Check initial value');
+
+    @include assert-equal(
+      $assert,
+      join((), 'assert'));
+
+    @include assert-equal(
+      $expect,
+      ('assert' 'expect'));
+
+    @include assert-equal(
+      $output,
+      ('assert' 'expect' 'output'));
+  }
+
+  @include test('Resets context') {
+    @include assert-equal(
+      $reset,
+      $before);
+  }
+
+  // @include expect { /* test that this breaks things */ }
+  // @include output { /* test that this breaks things */ }
+  // @include assert { /* test that this breaks things */ }
+  // @include assert {
+  //   @include expect { /* nothing */ }
+  //   @include expect { /* an error */ }
+  // }
+}

--- a/test/scss/_output.scss
+++ b/test/scss/_output.scss
@@ -27,9 +27,11 @@
   }
 
   @include test('String') {
+    $string: unquote('hello world');
+
     @include assert-equal(
-      _true-variable-details('hello world'),
-      '[string] hello world');
+      _true-variable-details($string),
+      '[string] #{$string}');
   }
 
   @include test('Color') {
@@ -79,6 +81,19 @@
     @include assert-equal(
       _true-edgefail-notes($list, $string),
       $message);
+  }
+
+  $string-one: unquote('hello world');
+  $string-two: quote('hello world');
+
+  @if ($string-one != $string-two) {
+    @include test('String quotes') {
+      $message: '- Details: string quotations do not match';
+
+      @include assert-equal(
+        _true-edgefail-notes($string-one, $string-two),
+        $message);
+    }
   }
 
   @include test('Number rounding') {


### PR DESCRIPTION
Fixes #71 

- [x] error when missing `assert`
- [x] error when nested `assert`
- [x] error when missing `expect` or`output`
- [x] error when multiple `expect` or`output`
- [x] internal documentation