### PR TITLE
[WIP] Enable the ability to run tests over sets of data (ie. a data provider).

### DIFF
--- a/sass/_true.scss
+++ b/sass/_true.scss
@@ -15,5 +15,6 @@
 // API
 @import 'true/modules';
 @import 'true/tests';
+@import 'true/providers';
 @import 'true/assert';
 @import 'true/report';

--- a/sass/true/_providers.scss
+++ b/sass/true/_providers.scss
@@ -24,7 +24,7 @@ $_providers: ();
 ///   ));
 ///
 ///   @include test('Mathematics') {
-///     @include test-provider('maths') using ($output, $expected) {
+///     @include test-provider('maths') using ($i, $output, $expected) {
 ///       @include assert-true($output, $expected);
 ///     }
 ///   }
@@ -47,7 +47,7 @@ $_providers: ();
 /// @group api-data-provider
 /// @param {string} $name - The name of the provided
 /// @content Include all the tests & modules that are part of this module,
-///   passing the data set of the specified provider
+///   passing the index and data of the current iteration of the specified provider
 /// @throw When the specified data provider has not been defined.
 /// @example scss -
 ///   @include data-provider('maths', (
@@ -55,9 +55,19 @@ $_providers: ();
 ///     (4 * 5, 20)
 ///   ));
 ///
-///   @include test('Mathematics') {
-///     @include test-provider('maths') using ($output, $expected) {
-///       @include assert-true($output, $expected);
+///   @include test-module('Mathematics') {
+///     // Test 1
+///     @include test('Test 1') {
+///       @include test-provider('maths') using ($i, $output, $expected) {
+///         @include assert-true($output, $expected);
+///       }
+///     }
+///
+///     // Test 2
+///     @include test-provider('maths') using ($i, $output, $expected) {
+///       @include test('Test 2 with data set ##{i} [#{$output}]') {
+///         @include assert-true($output, $expected);
+///       }
 ///     }
 ///   }
 @mixin test-provider(
@@ -70,21 +80,20 @@ $_providers: ();
     @include _true-error($error, 'provider');
   }
 
-  @each $data-set in $provider {
-    @content($data-set...);
+  @for $index from 1 through length($provider) {
+    @content($index, nth($provider, $index)...);
   }
 }
 
-// Describe Each
+// For
 // -----------
 /// Describe the unit to be tested and the iterable data set it receives.
 /// This works just like a test module combine with test provider.
 /// @access public
 /// @group api-data-provider
-/// @param {string} $name - module name
-/// @param {string} $data-set - A list of data which a test will iterate upon
+/// @param {string | list} $provider - The name of the provided or a list of data which a test will iterate upon
 /// @content Include all the tests that are part of this module,
-///   passing the data set of the specified provider
+///   passing the index and data of the current iteration of the specified provider
 /// @example scss -
 ///   @include data-provider('maths', (
 ///     (1 + 3, 4),
@@ -92,27 +101,41 @@ $_providers: ();
 ///   ));
 ///
 ///   @include describe('Mathematics') {
-///     @include it('Returns two lists zipped together') {
-///       // Test 1
-///       @include for('maths') using ($output, $expected) {
+///     // Test 1
+///     @include it('Test 1') {
+///       @include for('maths') using ($i, $output, $expected) {
 ///         @include assert-true($output, $expected);
 ///       }
+///     }
 ///
-///       // Test 2
-///       @include for((
-///         (1 + 3, 4),
-///         (4 * 5, 20)
-///       )) using ($output, $expected) {
+///     // Test 2
+///     @include for('maths') using ($i, $output, $expected) {
+///       @include it('Test 2 with data set ##{i} [#{$output}]') {
+///         @include assert-true($output, $expected);
+///       }
+///     }
+///
+///     // Test 3
+///     @include for((
+///       (1 + 3, 4),
+///       (4 * 5, 20)
+///     )) using ($i, $output, $expected) {
+///       @include it('Test 3 with data set ##{i} [#{$output}]') {
 ///         @include assert-true($output, $expected);
 ///       }
 ///     }
 ///   }
 @mixin for(
-  $name, $data-set
+  $provider
 ) {
-  $key: unique-id();
-  @include data-provider($key, $data-set);
-  @include test-provider($key) using ($data-set...) {
-    @content($data-set...);
+  $name: $provider;
+  
+  @if type-of($provider) != 'string' {
+    $name: unique-id();
+    @include data-provider($name, $provider);
+  }
+
+  @include test-provider($name) using ($args...) {
+    @content($args...);
   }
 }

--- a/sass/true/_providers.scss
+++ b/sass/true/_providers.scss
@@ -1,0 +1,118 @@
+// Data Providers
+// =============
+
+// Providers [variable]
+// ------------------
+/// Stores the configured data providers
+/// @access private
+/// @group private-data-provider
+/// @type map
+$_providers: ();
+
+// Data Provider
+// -----------
+/// Configures a data provider.
+/// @access public
+/// @group api-data-provider
+/// @param {string} $name - The name of the provided
+/// @param {list} $data-set - A list of data which a test will iterate upon
+/// @throw When the provider has previously be defined
+/// @example scss -
+///   @include data-provider('maths', (
+///     (1 + 3, 4),
+///     (4 * 5, 20)
+///   ));
+///
+///   @include test('Mathematics') {
+///     @include test-provider('maths') using ($output, $expected) {
+///       @include assert-true($output, $expected);
+///     }
+///   }
+@mixin data-provider (
+  $name,
+  $data-set
+) {
+  @if map-has-key($_providers, $name) {
+    $error: 'This provider has been perviously be defined and cannot be reconfigured.';
+    @include _true-error($error, 'provider');
+  }
+
+  $_providers: map-merge($_providers, ($name: $data-set)) !global;
+}
+
+// Test Provider
+// -----------
+/// Iterates a test over the specified data provider.
+/// @access public
+/// @group api-data-provider
+/// @param {string} $name - The name of the provided
+/// @content Include all the tests & modules that are part of this module,
+///   passing the data set of the specified provider
+/// @throw When the specified data provider has not been defined.
+/// @example scss -
+///   @include data-provider('maths', (
+///     (1 + 3, 4),
+///     (4 * 5, 20)
+///   ));
+///
+///   @include test('Mathematics') {
+///     @include test-provider('maths') using ($output, $expected) {
+///       @include assert-true($output, $expected);
+///     }
+///   }
+@mixin test-provider(
+  $name
+) {
+  $provider: map-get($_providers, $name);
+
+  @if $provider == null {
+    $error: 'No provider for [#{$name}] has been defined.';
+    @include _true-error($error, 'provider');
+  }
+
+  @each $data-set in $provider {
+    @content($data-set...);
+  }
+}
+
+// Describe Each
+// -----------
+/// Describe the unit to be tested and the iterable data set it receives.
+/// This works just like a test module combine with test provider.
+/// @access public
+/// @group api-data-provider
+/// @param {string} $name - module name
+/// @param {string} $data-set - A list of data which a test will iterate upon
+/// @content Include all the tests that are part of this module,
+///   passing the data set of the specified provider
+/// @example scss -
+///   @include data-provider('maths', (
+///     (1 + 3, 4),
+///     (4 * 5, 20)
+///   ));
+///
+///   @include describe('Mathematics') {
+///     @include it('Returns two lists zipped together') {
+///       // Test 1
+///       @include for('maths') using ($output, $expected) {
+///         @include assert-true($output, $expected);
+///       }
+///
+///       // Test 2
+///       @include for((
+///         (1 + 3, 4),
+///         (4 * 5, 20)
+///       )) using ($output, $expected) {
+///         @include assert-true($output, $expected);
+///       }
+///     }
+///   }
+@mixin for(
+  $name, $data-set
+) {
+  $key: unique-id();
+  @include data-provider($key, $data-set);
+  @include test-provider($key) using ($data-set...) {
+    @content($data-set...);
+  }
+}


### PR DESCRIPTION
## Description
Many test frameworks have a method defining tests which should operate on a defined set of data. For example, PHPUnit has a [`@dataProvider` annotation](https://phpunit.readthedocs.io/en/9.0/writing-tests-for-phpunit.html#data-providers) which specifics the member which provides iterator to the test for its parameters. Likewise, Jest has an [`test.each` method](https://jestjs.io/docs/en/api#testeachtablename-fn-timeout) which functions in a similar manner.

I have implemented Sass mixins to achieve the desired functionality. I don't believe there is any reason to alter scripts or other portions of the True.

## Steps to test
I have this tested on `dart-sass`, however the True is using `node-sass` for its tests. The current version of node-sass doesn't support passing arguments from a mixin to a content block (https://github.com/sass/node-sass/issues/2685).

Here are the test which I have written in the SassDocs:

```scss
@include data-provider('maths', (
  (1 + 3, 4),
  (4 * 5, 20)
));

// TTD
@include test-module('Mathematics') {
  // Test 1
  @include test('Test 1') {
    @include test-provider('maths') using ($i, $output, $expected) {
      @include assert-true($output, $expected);
    }
  }

  // Test 2
  @include test-provider('maths') using ($i, $output, $expected) {
    @include test('Test 2 with data set ##{i} [#{$output}]') {
      @include assert-true($output, $expected);
    }
  }
}

// BBD
@include describe('Mathematics') {
  // Test 1
  @include it('Test 1') {
    @include for('maths') using ($i, $output, $expected) {
      @include assert-true($output, $expected);
    }
  }

  // Test 2
  @include for('maths') using ($i, $output, $expected) {
    @include it('Test 2 with data set ##{i} [#{$output}]') {
      @include assert-true($output, $expected);
    }
  }

  // Test 3
  // Note: It seems defining the set nearer the test is common with BBD,
  // but not suggested with TTD; therefore, this interface was not made
  // available for the TTD pattern.
  @include for((
    (1 + 3, 4),
    (4 * 5, 20)
  )) using ($i, $output, $expected) {
    @include it('Test 3 with data set ##{i} [#{$output}]') {
      @include assert-true($output, $expected);
    }
  }
}
```

## Tasks
- [ ] Discuss and determine API
- [ ] See the release of node-sass w/libsass 3.6
- [ ] Write tests

---

## Reviewer tasks:

- [ ] Pulled branch and ran code locally (or viewed on preview deployment, if applicable)
- [ ] Reproduced the issue to review in the browser
- [ ] Reviewed code
- [ ] Updated Trello card (if applicable)
